### PR TITLE
Utilize the GlobalState Player Count

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -70,19 +70,17 @@ CreateThread(function()
             if not scoreboardOpen then
                 exports['qbr-core']:TriggerCallback('qbr-scoreboard:server:GetPlayersArrays', function(playerList)
                     exports['qbr-core']:TriggerCallback('qbr-scoreboard:server:GetActivity', function(cops, ambulance)
-                        exports['qbr-core']:TriggerCallback("qbr-scoreboard:server:GetCurrentPlayers", function(Players)
-                            PlayerOptin = playerList
-                            Config.CurrentCops = cops
-                            SendNUIMessage({
-                                action = "open",
-                                players = Players,
-                                maxPlayers = Config.MaxPlayers,
-                                requiredCops = Config.IllegalActions,
-                                currentCops = Config.CurrentCops,
-                                currentAmbulance = ambulance
-                            })
-                            scoreboardOpen = true
-                        end)
+						PlayerOptin = playerList
+						Config.CurrentCops = cops
+						SendNUIMessage({
+							action = "open",
+							players = GlobalState['Count:Players'],
+							maxPlayers = Config.MaxPlayers,
+							requiredCops = Config.IllegalActions,
+							currentCops = Config.CurrentCops,
+							currentAmbulance = ambulance
+						})
+						scoreboardOpen = true
                     end)
                 end)
             else

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -17,3 +17,5 @@ server_scripts {
 files {
     "html/*"
 }
+
+lua54 'yes'

--- a/server.lua
+++ b/server.lua
@@ -1,11 +1,3 @@
-exports['qbr-core']:CreateCallback('qbr-scoreboard:server:GetCurrentPlayers', function(source, cb)
-    local TotalPlayers = 0
-    for k, v in pairs(exports['qbr-core']:GetPlayers()) do
-        TotalPlayers += 1
-    end
-    cb(TotalPlayers)
-end)
-
 exports['qbr-core']:CreateCallback('qbr-scoreboard:server:GetActivity', function(source, cb)
     local PoliceCount, AmbulanceCount = 0, 0
     for k, v in pairs(exports['qbr-core']:GetPlayers()) do


### PR DESCRIPTION
NOTE: Requires Latest Core to work as using the GlobalState['Count:Player']

This will remove the need to check on the server callback for player count. Also added lua54 support to the fxmanifest to fix syntax error as the last PR wasnt pulled. 