### PR TITLE
Add Global State Player Count

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -70,19 +70,17 @@ CreateThread(function()
             if not scoreboardOpen then
                 exports['qbr-core']:TriggerCallback('qbr-scoreboard:server:GetPlayersArrays', function(playerList)
                     exports['qbr-core']:TriggerCallback('qbr-scoreboard:server:GetActivity', function(cops, ambulance)
-                        exports['qbr-core']:TriggerCallback("qbr-scoreboard:server:GetCurrentPlayers", function(Players)
-                            PlayerOptin = playerList
-                            Config.CurrentCops = cops
-                            SendNUIMessage({
-                                action = "open",
-                                players = Players,
-                                maxPlayers = Config.MaxPlayers,
-                                requiredCops = Config.IllegalActions,
-                                currentCops = Config.CurrentCops,
-                                currentAmbulance = ambulance
-                            })
-                            scoreboardOpen = true
-                        end)
+						PlayerOptin = playerList
+						Config.CurrentCops = cops
+						SendNUIMessage({
+							action = "open",
+							players = GlobalState['Count:Players'],
+							maxPlayers = Config.MaxPlayers,
+							requiredCops = Config.IllegalActions,
+							currentCops = Config.CurrentCops,
+							currentAmbulance = ambulance
+						})
+						scoreboardOpen = true
                     end)
                 end)
             else

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -17,3 +17,5 @@ server_scripts {
 files {
     "html/*"
 }
+
+lua54 'yes'

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,15 +4,11 @@ rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aw
 
 ui_page "html/ui.html"
 
-client_scripts {
-    'client.lua',
-	'config.lua',
-}
+shared_script 'config.lua'
 
-server_scripts {
-	'config.lua',
-	'server.lua',
-}
+client_script 'client.lua'
+
+server_script 'server.lua'
 
 files {
     "html/*"

--- a/server.lua
+++ b/server.lua
@@ -1,11 +1,3 @@
-exports['qbr-core']:CreateCallback('qbr-scoreboard:server:GetCurrentPlayers', function(source, cb)
-    local TotalPlayers = 0
-    for k, v in pairs(exports['qbr-core']:GetPlayers()) do
-        TotalPlayers += 1
-    end
-    cb(TotalPlayers)
-end)
-
 exports['qbr-core']:CreateCallback('qbr-scoreboard:server:GetActivity', function(source, cb)
     local PoliceCount, AmbulanceCount = 0, 0
     for k, v in pairs(exports['qbr-core']:GetPlayers()) do


### PR DESCRIPTION
NOTE: Requires Latest Core to work as using the GlobalState['Count:Player']

This removes the Callback to check Player Count and uses Global State as well as adds lua54 support to fix the Syntax error on server as last PR wasn't pulled.